### PR TITLE
Feature/comments create fix 3

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,34 +10,25 @@ class CommentsController < ApplicationController
   end
 
   def create
-    client = HotelService.new(ENV["RAKUTEN_API_KEY"])
-    hotel_info = client.get_hotel_details(params[:hotel_id])
-
-    unless hotel_info
-      flash[:alert] = "ホテルが見つかりませんでした。"
-      redirect_to hotels_path
-      return
-    end
-
-    # 内部IDを生成 or 取得
-    hotel_record = client.save_hotel_to_db(hotel_info)
+    @hotel_record = Hotel.find(params[:hotel_id])  # ← 内部IDで取得
 
     @comment = Comment.new(comment_params)
     @comment.user  = current_user
-    @comment.hotel = hotel_record # ← 内部IDで紐づける
+    @comment.hotel = @hotel_record
 
     if @comment.save
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to hotel_path(@comment.hotel.external_id), notice: "コメントが投稿されました。" }
+        format.html { redirect_to hotel_path(@hotel_record.id), notice: "コメントが投稿されました。" }
       end
     else
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to hotel_path(hotel_record.external_id), alert: "コメントの投稿に失敗しました。" }
+        format.html { redirect_to hotel_path(@hotel_record.id), alert: "コメントの投稿に失敗しました。" }
       end
     end
   end
+
 
   def edit
   end
@@ -46,7 +37,7 @@ class CommentsController < ApplicationController
     @hotel = @comment.hotel
 
     if @comment.update(comment_params)
-      redirect_to hotel_path(@hotel), notice: "コメントが更新されました。"
+      redirect_to hotel_path(@comment.hotel.id), notice: "コメントが更新されました。"
     else
       render :edit
     end
@@ -57,7 +48,7 @@ class CommentsController < ApplicationController
     @hotel = @comment.hotel
 
     @comment.destroy
-    redirect_to hotel_path(@hotel), notice: "コメントが削除されました。"
+    redirect_to hotel_path(@comment.hotel.id), notice: "コメントが削除されました。"
   end
 
   private

--- a/app/controllers/hotels_controller.rb
+++ b/app/controllers/hotels_controller.rb
@@ -29,6 +29,7 @@ def show
     # 内部IDでアクセスされた場合
     @hotel_record = Hotel.find(params[:id])
     external_id = @hotel_record.external_id
+    @hotel_id = @hotel_record.id
     
     # API を叩く必要はない（DB の情報で十分）
     @hotel = {
@@ -71,6 +72,7 @@ def show
 
     # DB に保存して内部IDへリダイレクト
     @hotel_record = client.save_hotel_to_db(@hotel)
+    @hotel_id = @hotel_record.id
     redirect_to hotel_path(@hotel_record.id) and return
   end
 

--- a/app/views/comments/all.html.erb
+++ b/app/views/comments/all.html.erb
@@ -4,6 +4,12 @@
   <% @comments.each do |comment| %>
     <div class="comment mb-3 p-3 border">
       <div>
+        <p> <img src="<%= comment.hotel.hotel_image_url %>" 
+                 class="img-fluid rounded mb-2" style="max-width: 50%; height: auto;
+                 "alt="hotel image"></p>
+        <p class="fs-5 fw-bold"> <%= comment.hotel.name %></p>
+        <p><%= comment.hotel.hotel_special %></p>
+        <%= link_to "楽天で見る", comment.hotel.hotel_information_url, target: "_blank" %>
         <p><strong><%= comment.user.name %></strong></p>
         <p><%= comment.body %></p>
         <small class="text-muted">

--- a/app/views/hotels/index.html.erb
+++ b/app/views/hotels/index.html.erb
@@ -31,7 +31,7 @@
         <% end %>
 
           <%= link_to 'みんなの旅ログをみる', 
-            hotel_path(id: hotel["id"], return_to: request.fullpath), 
+            hotel_path(id: hotel["id"]), 
             class: "btn btn-primary d-inline-block",
             data: { turbo: false } %>
           <a href="<%= hotel['hotelInformationUrl'] %>" target="_blank">詳細情報(楽天トラベル)</a>

--- a/app/views/hotels/show.html.erb
+++ b/app/views/hotels/show.html.erb
@@ -29,6 +29,6 @@
   <div class="row">
     <div class="col-lg-8 offset-lg-2">
   <div class="mb-3">
-<%= link_to '戻る', 'javascript:history.back()', class: 'btn btn-secondary' %>
+<%= link_to "検索結果に戻る", session[:last_search_url] || hotels_path %>
   </div>
 </div>

--- a/app/views/hotels/show.html.erb
+++ b/app/views/hotels/show.html.erb
@@ -25,7 +25,7 @@
       </article>
     </div>
   </div>
-  <%= render 'comments/form', comment: @comment, hotel: @hotel if logged_in? %>
+  <%= render 'comments/form', comment: @comment, hotel: @hotel_id if logged_in? %>
   <div class="row">
     <div class="col-lg-8 offset-lg-2">
   <div class="mb-3">

--- a/app/views/tags/_tags.html.erb
+++ b/app/views/tags/_tags.html.erb
@@ -49,7 +49,7 @@
   <% else %>
     <%= link_to 'タグを追加',
         login_path,
-        data: { turbo_frame: "hotel_#{frame_id}_tags_form" },
+        data: { turbo: false },
         class: 'btn btn-primary d-inline-block' %>
   <% end %>
 <% end %>


### PR DESCRIPTION
概要
・「みんなの旅ログボタン」を押した際のエラーを解消し、コメント一覧にアクセスできるようになりました。
・コメント投稿時の画面遷移を現在のページのままに更新できるようにしました。
・コメント削除・更新時の不具合を修正しました。

変更点
・hotelsコントローラーのshowアクションにおいて、```@hotel_id = @hotel_record.id```をセットし、内部IDを@hote_idとして渡せるように変更しました。
・hotelsコントローラーのshowアクションでDBにホテル情報を保存し、commentsコントローラーにおいては、内部IDでのみhotel情報を扱えるようになり、リダイレクト先を内部IDに修正・統一しました。

効果
みんなの旅ログボタンをおした際に正常にコメント一覧に遷移します。
コメント投稿時にはturboで新規コメントが一覧に追加されます。
コメントの更新・編集後はもとのホテルのコメント投稿画面(コメント一覧画面)に遷移するようになり、のユーザー体験が自然になりました。

問題点
他ページからアクセスした際の挙動も確認していく必要があります。
