### PR TITLE
Feature/map details tag

### DIFF
--- a/app/controllers/hotels_controller.rb
+++ b/app/controllers/hotels_controller.rb
@@ -31,7 +31,7 @@ def show
     external_id = @hotel_record.external_id
     @hotel_id = @hotel_record.id
 
-    # API を叩く必要はない（DB の情報で十分）
+    # API を叩く必要はない（DBの情報で十分）
     @hotel = {
       "hotelName" => @hotel_record.name,
       "hotelImageUrl" => @hotel_record.hotel_image_url,

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -40,19 +40,18 @@ class MapsController < ApplicationController
     hotel_no = params[:id]
     client = HotelService.new(ENV["RAKUTEN_API_KEY"])
 
-    # API から1件取得（DB保存はしない）
-    response = client.get_hotel_details(hotel_no)
-    if response.nil?
-      flash[:alert] = "ホテル情報が見つかりません。"
+    # ここで返ってくるのは hotelBasicInfo の Hash
+    info = client.get_hotel_details(hotel_no)
+
+    if info.nil?
+      flash[:alert] = "ホテル情報が取得できませんでした。"
       redirect_to maps_path and return
     end
-
-    info = response["hotel"][0]["hotelBasicInfo"]
-
-    # DB にホテルが存在する場合のみタグ表示に使う
-    @hotel_record = Hotel.includes(hotel_tags: :tag).find_by(external_id: hotel_no)
-
-    # view 用
+  
+    # そのまま使う
     @hotel = info
+
+    # タグ用（存在する場合のみ）
+   @hotel_record = Hotel.includes(hotel_tags: :tag).find_by(external_id: hotel_no)
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -9,7 +9,7 @@ class MapsController < ApplicationController
     if all_hotels.present?
        # ① まず hotelNo を全部抜き出す
        hotel_nos = all_hotels.map { |h| h["hotel"][0]["hotelBasicInfo"]["hotelNo"] }
-        
+
       # ② DB の Hotel レコードを一括取得（SQL 1回）
       hotel_records = Hotel
         .where(external_id: hotel_nos)

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -21,7 +21,7 @@ class MapsController < ApplicationController
         info = hotel["hotel"][0]["hotelBasicInfo"]
         coordinates = CoordinateConverter.to_wgs84(info["latitude"], info["longitude"])
 
-        { 
+        {
           hotelNo: info["hotelNo"],
           name: info["hotelName"],
           latitude: coordinates[:latitude],
@@ -47,11 +47,11 @@ class MapsController < ApplicationController
       flash[:alert] = "ホテル情報が取得できませんでした。"
       redirect_to maps_path and return
     end
-  
+
     # そのまま使う
     @hotel = info
 
-    # タグ用（存在する場合のみ）
+   # タグ用（存在する場合のみ）
    @hotel_record = Hotel.includes(hotel_tags: :tag).find_by(external_id: hotel_no)
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -38,27 +38,21 @@ class MapsController < ApplicationController
 
   def details
     hotel_no = params[:id]
-    hotel_service = HotelService.new(ENV["RAKUTEN_API_KEY"])
+    client = HotelService.new(ENV["RAKUTEN_API_KEY"])
 
-    # APIからホテル情報を取得
-    hotel_info = hotel_service.get_hotel_details(hotel_no, fields: [ "hotelName", "hotelSpecial", "hotelImageUrl", "hotelInformationUrl" ])
-
-    # ホテル情報が見つからない場合の処理
-    if hotel_info.nil?
-      Rails.logger.error "Hotel details not found for ID: #{hotel_no}"
+    # API から1件取得（DB保存はしない）
+    response = client.get_hotel_details(hotel_no)
+    if response.nil?
       flash[:alert] = "ホテル情報が見つかりません。"
       redirect_to maps_path and return
     end
 
-    # ホテルタグを取得して追加
-    tags = HotelTag.where(hotel_id: hotel_no).includes(:tag).map { |hotel_tag| hotel_tag.tag.name }
-    hotel_info["tags"] = tags
+    info = response["hotel"][0]["hotelBasicInfo"]
 
-    @hotel = hotel_info
-    @hotel["hotelNo"] ||= hotel_no # 必要に応じてhotelNoを補完
+    # DB にホテルが存在する場合のみタグ表示に使う
+    @hotel_record = Hotel.includes(hotel_tags: :tag).find_by(external_id: hotel_no)
 
-    # タグ作成フォーム用のインスタンス変数
-    @hotel_tag = HotelTag.new
-    @hotel_id = hotel_no
+    # view 用
+    @hotel = info
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -3,22 +3,30 @@ class MapsController < ApplicationController
     @google_maps_api_key = ENV["GOOGLE_MAPS_API_KEY"]
 
     keyword = "オールインクルーシブ"
-    Rails.logger.info "Fetching all hotels with keyword: '#{keyword}'"
-
     hotel_service = HotelService.new(ENV["RAKUTEN_API_KEY"])
     all_hotels = hotel_service.fetch_all_hotels(keyword)
 
     if all_hotels.present?
+       # ① まず hotelNo を全部抜き出す
+       hotel_nos = all_hotels.map { |h| h["hotel"][0]["hotelBasicInfo"]["hotelNo"] }
+        
+      # ② DB の Hotel レコードを一括取得（SQL 1回）
+      hotel_records = Hotel
+        .where(external_id: hotel_nos)
+        .includes(hotel_tags: :tag)
+        .index_by(&:external_id)
+
+      # ③ map の中では DB を叩かない
       @hotels = all_hotels.map do |hotel|
-        hotel_info = hotel["hotel"][0]["hotelBasicInfo"]
-        coordinates = CoordinateConverter.to_wgs84(hotel_info["latitude"], hotel_info["longitude"])
+        info = hotel["hotel"][0]["hotelBasicInfo"]
+        coordinates = CoordinateConverter.to_wgs84(info["latitude"], info["longitude"])
 
         {
-          hotelNo: hotel_info["hotelNo"],
-          name: hotel_info["hotelName"],
+          name: info["hotelName"],
           latitude: coordinates[:latitude],
           longitude: coordinates[:longitude],
-          info_content: "<h3>#{hotel_info['hotelName']}</h3><p>#{hotel_info['hotelSpecial']}</p>"
+          hotel_record: hotel_records[info["hotelNo"]],
+          info_content: "<h3>#{info['hotelName']}</h3><p>#{info['hotelSpecial']}</p>"
         }
       end
     else
@@ -28,28 +36,28 @@ class MapsController < ApplicationController
   end
 
   def details
-  hotel_no = params[:id]
-  hotel_service = HotelService.new(ENV["RAKUTEN_API_KEY"])
+    hotel_no = params[:id]
+    hotel_service = HotelService.new(ENV["RAKUTEN_API_KEY"])
 
-  # APIからホテル情報を取得
-  hotel_info = hotel_service.get_hotel_details(hotel_no, fields: [ "hotelName", "hotelSpecial", "hotelImageUrl", "hotelInformationUrl" ])
+    # APIからホテル情報を取得
+    hotel_info = hotel_service.get_hotel_details(hotel_no, fields: [ "hotelName", "hotelSpecial", "hotelImageUrl", "hotelInformationUrl" ])
 
-  # ホテル情報が見つからない場合の処理
-  if hotel_info.nil?
-    Rails.logger.error "Hotel details not found for ID: #{hotel_no}"
-    flash[:alert] = "ホテル情報が見つかりません。"
-    redirect_to maps_path and return
-  end
+    # ホテル情報が見つからない場合の処理
+    if hotel_info.nil?
+      Rails.logger.error "Hotel details not found for ID: #{hotel_no}"
+      flash[:alert] = "ホテル情報が見つかりません。"
+      redirect_to maps_path and return
+    end
 
-  # ホテルタグを取得して追加
-  tags = HotelTag.where(hotel_id: hotel_no).includes(:tag).map { |hotel_tag| hotel_tag.tag.name }
-  hotel_info["tags"] = tags
+    # ホテルタグを取得して追加
+    tags = HotelTag.where(hotel_id: hotel_no).includes(:tag).map { |hotel_tag| hotel_tag.tag.name }
+    hotel_info["tags"] = tags
 
-  @hotel = hotel_info
-  @hotel["hotelNo"] ||= hotel_no # 必要に応じてhotelNoを補完
+    @hotel = hotel_info
+    @hotel["hotelNo"] ||= hotel_no # 必要に応じてhotelNoを補完
 
-  # タグ作成フォーム用のインスタンス変数
-  @hotel_tag = HotelTag.new
-  @hotel_id = hotel_no
+    # タグ作成フォーム用のインスタンス変数
+    @hotel_tag = HotelTag.new
+    @hotel_id = hotel_no
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -21,7 +21,8 @@ class MapsController < ApplicationController
         info = hotel["hotel"][0]["hotelBasicInfo"]
         coordinates = CoordinateConverter.to_wgs84(info["latitude"], info["longitude"])
 
-        {
+        { 
+          hotelNo: info["hotelNo"],
           name: info["hotelName"],
           latitude: coordinates[:latitude],
           longitude: coordinates[:longitude],

--- a/app/controllers/oauth_callbacks_controller.rb
+++ b/app/controllers/oauth_callbacks_controller.rb
@@ -24,7 +24,7 @@ class OauthCallbacksController < ApplicationController
   end
 
   def google
-    auth = request.env["omniauth.auth"] #googleが返したJson形式のデータが入っている
+    auth = request.env["omniauth.auth"] # googleが返したJson形式のデータが入っている
 
     if auth.nil? || !auth["provider"] || !auth["uid"]
       redirect_to new_user_path, alert: "認証情報が取得できませんでした。"

--- a/app/javascript/maps.js
+++ b/app/javascript/maps.js
@@ -17,6 +17,8 @@ document.addEventListener("DOMContentLoaded", () => {
   // マーカー追加
   function addMarkers(hotels) {
     hotels.forEach((hotel, i) => {
+      if (!hotel) return; // ← null をスキップ
+      
       const lat = parseFloat(hotel.latitude);
       const lng = parseFloat(hotel.longitude);
       if (Number.isNaN(lat) || Number.isNaN(lng)) return;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,25 +20,25 @@ class User < ApplicationRecord
     user if user && user.authenticate(password)
   end
 
- # SNS から返ってきた auth 情報を元にユーザーを作成 or 取得するクラスメソッド
+  # SNS から返ってきた auth 情報を元にユーザーを作成 or 取得するクラスメソッド
   def self.from_omniauth(auth)
-    #この2つで既存ユーザーを検索していく。provider:sns、uid:sns側のユーザー
+    # この2つで既存ユーザーを検索していく。provider:sns、uid:sns側のユーザー
     user = where(provider: auth.provider, uid: auth.uid).first_or_initialize
 
-    #SNSから返ってきた情報を User に反映する。
+    # SNSから返ってきた情報を User に反映する。
     user.provider = auth.provider
     user.uid      = auth.uid
     user.name     = auth.info.name if auth.info.name.present?
 
-   #googleはemail情報を返すが、twitterは返さないためダミー作成
+    # googleはemail情報を返すが、twitterは返さないためダミー作成
     if auth.info.email.present?
       user.email = auth.info.email
     else
       user.email ||= "#{auth.uid}@twitter.com"
     end
 
-    #SNSログインユーザーはパスワードを入力しないため、ランダムパスワードを生成&sorceryのバリデーションをスキップ
-    if user.new_record? #→既存ユーザーならスキップ
+    # SNSログインユーザーはパスワードを入力しないため、ランダムパスワードを生成&sorceryのバリデーションをスキップ
+    if user.new_record? # →既存ユーザーならスキップ
       user.password = SecureRandom.hex(10)
       user.password_confirmation = user.password
       user.skip_password_validation = true

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -39,6 +39,6 @@
   <% end %>
 
   <h2>地図から探す</h2>
-  <%= link_to '地図を見る', maps_path, class: "btn btn-primary" %>
+  <%= link_to '地図を見る', maps_path, class: "btn btn-primary", data: { turbo: false } %>
 </body>
 </html>

--- a/app/views/maps/details.html.erb
+++ b/app/views/maps/details.html.erb
@@ -8,14 +8,12 @@
   <p><%= @hotel['hotelSpecial'] %></p>
 
   <!-- タグ部分だけをフレームにする -->
-  <% frame_id = "hotel_#{@hotel['hotelNo']}_tags" %>
+  <% frame_id = @hotel['hotelNo'] %>
   <div class="tag-section">
-    <%= turbo_frame_tag frame_id do %>
       <%= render 'tags/tags', 
           hotel: @hotel, 
           hotel_record: @hotel_record, 
           frame_id: frame_id %>
-    <% end %>
   </div>
 
   <!-- フレームの外にリンクやボタンを置く -->
@@ -24,7 +22,7 @@
       hotel_path(@hotel['hotelNo']),
       class: "btn btn-primary d-inline-block",
       data: { turbo: false } %>
-      
+
     <a href="<%= @hotel['hotelInformationUrl'] %>" target="_blank">詳細情報(楽天トラベル)</a>
     <%= render 'bookmark_buttons', hotel: @hotel %>
   </div>

--- a/app/views/maps/details.html.erb
+++ b/app/views/maps/details.html.erb
@@ -11,7 +11,7 @@
   <% frame_id = "hotel_#{@hotel['hotelNo']}_tags" %>
   <div class="tag-section">
     <%= turbo_frame_tag frame_id do %>
-      <%= render 'tags/tags', hotel: @hotel, frame_id: frame_id %>
+      <%= render 'tags/tags', hotel: @hotel, hotel_record: @hotel_record, frame_id: frame_id %>
     <% end %>
   </div>
 

--- a/app/views/maps/details.html.erb
+++ b/app/views/maps/details.html.erb
@@ -11,7 +11,10 @@
   <% frame_id = "hotel_#{@hotel['hotelNo']}_tags" %>
   <div class="tag-section">
     <%= turbo_frame_tag frame_id do %>
-      <%= render 'tags/tags', hotel: @hotel, hotel_record: @hotel_record, frame_id: frame_id %>
+      <%= render 'tags/tags', 
+          hotel: @hotel, 
+          hotel_record: @hotel_record, 
+          frame_id: frame_id %>
     <% end %>
   </div>
 
@@ -21,6 +24,7 @@
       hotel_path(@hotel['hotelNo']),
       class: "btn btn-primary d-inline-block",
       data: { turbo: false } %>
+      
     <a href="<%= @hotel['hotelInformationUrl'] %>" target="_blank">詳細情報(楽天トラベル)</a>
     <%= render 'bookmark_buttons', hotel: @hotel %>
   </div>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for :head do %>
+<meta name="turbo-visit-control" content="reload">
   <style>
     #map { height: 500px; width: 100%; }
   </style>
 <% end %>
 
-<div data-turbo="false">
   <h1>オールインクルーシブホテルを地図から探す</h1>
 
   <div id="map"
@@ -14,5 +14,5 @@
   <div>
     <%= link_to 'ホームに戻る', root_path, class: 'btn btn-primary' %>
   </div>
-</div>
+
 

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,5 +1,4 @@
 <% content_for :head do %>
-  <meta name="turbo-visit-control" content="reload">
   <style>
     #map { height: 500px; width: 100%; }
   </style>


### PR DESCRIPTION
目的：
地図検索検索結果からホテルをクリック→ ```HotelsController#index ```の「ホテル1件だけ表示版」に遷移する。
すなわち、ワード検索時に作成されたタグやコメントと、地図検索時に作成されたタグやコメントの内容を統一していずれでも表示されているようにしたい。

実装：
・map表示の際のtagエラーを解消
　→タグ表示の際のviewに外部ID(hotel_records=hotelNo)を付与
・map表示時のN+1問題解消
　→一度すべての外部IDのみを取得→その後にDBをたたくことでDBに保存されているexternal_idがあるか検索をする

問題：エラーは解消されたが、map上のホテルクリック時に画面遷移がしなくなった
　→hotelコントローラーのdetailsとそのview周りを修正していく。