### PR TITLE
fix:googleログイン時のエラーを解消

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,8 @@ class User < ApplicationRecord
     else
       user.email ||= "#{auth.uid}@twitter.com"
     end
+    # SNSログイン時は常にパスワードバリデーションをスキップ
+    user.skip_password_validation = true
 
     # SNSログインユーザーはパスワードを入力しないため、ランダムパスワードを生成&sorceryのバリデーションをスキップ
     if user.new_record? # →既存ユーザーならスキップ


### PR DESCRIPTION
既存ユーザーがGoogleログインした際にsaveできずにエラーが出る問題を解消。
→既存ユーザーなのに、バリデーションの```password_presence```がに引っ掛かり、落ちていた。
DBをリセットした際にDBに入っていた既存ユーザーのcrypted_password が空になったことが原因と考えられる。

・新規ユーザーのときだけ ```skip_password_validation``` = true
・既存ユーザーのときは ```skip_password_validation``` が false のまま

改善案
SNSログイン時は常にパスワードバリデーションをスキップするように、
```user.skip_password_validation = true```を追記。